### PR TITLE
Same name for instances, memories and registers

### DIFF
--- a/kaze/src/graph/module.rs
+++ b/kaze/src/graph/module.rs
@@ -182,7 +182,16 @@ impl<'a> Module<'a> {
                 bit_width,
             },
         });
-        self.inputs.borrow_mut().insert(name, input);
+
+        let mut map = self.inputs.borrow_mut();
+        match map.entry(name) {
+            Entry::Vacant(v) => {
+                v.insert(input);
+            }
+            Entry::Occupied(_) => {
+                panic!("Cannot create an input with a name that already exists in this module.")
+            }
+        }
         input
     }
 
@@ -457,7 +466,6 @@ impl<'a> Module<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::verilog;
 
     #[test]
     #[should_panic(
@@ -756,5 +764,17 @@ mod tests {
 
         m.output("o", m.input("i1", 1));
         m.output("o", m.input("i2", 1));
+    }
+
+    #[test]
+    #[should_panic(
+        expected="Cannot create an input with a name that already exists in this module."
+    )]
+    fn inputs_same_name() {
+        let c = Context::new();
+        let m = c.module("A");
+
+        m.output("o1", m.input("i", 1));
+        m.output("o2", m.input("i", 1));
     }
 }

--- a/kaze/src/graph/module.rs
+++ b/kaze/src/graph/module.rs
@@ -174,26 +174,27 @@ impl<'a> Module<'a> {
             );
         }
         let mut map = self.inputs.borrow_mut();
-        match map.entry(name) {
+        match map.entry(name.clone()) {
             Entry::Vacant(v) => {
                 let input = self.context.signal_arena.alloc(Signal {
                     context: self.context,
                     module: self,
 
                     data: SignalData::Input {
-                        name: name.clone(),
+                        name,
                         bit_width,
                     },
                 });
 
 
                 v.insert(input);
+
+                input
             }
             Entry::Occupied(_) => {
                 panic!("Cannot create an input with a name that already exists in this module.")
             }
         }
-        input
     }
 
     /// Creates an output for this `Module` called `name` with the same number of bits as `source`, and drives this output with `source`.

--- a/kaze/src/validation.rs
+++ b/kaze/src/validation.rs
@@ -49,7 +49,7 @@ fn detect_recursive_definitions<'graph, 'frame>(
     module_stack_frame: &ModuleStackFrame<'graph, 'frame>,
     root: &graph::Module<'graph>,
 ) {
-    for instance in m.instances.borrow().iter() {
+    for instance in m.instances.borrow().values() {
         let instantiated_module = instance.instantiated_module;
 
         if ptr::eq(instantiated_module, m) {
@@ -91,7 +91,7 @@ fn detect_undriven_registers<'graph, 'frame>(
     module_stack_frame: &ModuleStackFrame<'graph, 'frame>,
     root: &graph::Module<'graph>,
 ) {
-    for register in m.registers.borrow().iter() {
+    for register in m.registers.borrow().values() {
         match register.data {
             graph::SignalData::Reg { ref data } => {
                 if data.next.borrow().is_none() {
@@ -102,7 +102,7 @@ fn detect_undriven_registers<'graph, 'frame>(
         }
     }
 
-    for instance in m.instances.borrow().iter() {
+    for instance in m.instances.borrow().values() {
         let instantiated_module = instance.instantiated_module;
 
         detect_undriven_registers(
@@ -121,7 +121,7 @@ fn detect_mem_errors<'graph, 'frame>(
     module_stack_frame: &ModuleStackFrame<'graph, 'frame>,
     root: &graph::Module<'graph>,
 ) {
-    for mem in m.mems.borrow().iter() {
+    for mem in m.mems.borrow().values() {
         if mem.read_ports.borrow().is_empty() {
             panic!("Cannot generate code for module \"{}\" because module \"{}\" contains a memory called \"{}\" which doesn't have any read ports.", root.name, m.name, mem.name);
         }
@@ -131,7 +131,7 @@ fn detect_mem_errors<'graph, 'frame>(
         }
     }
 
-    for instance in m.instances.borrow().iter() {
+    for instance in m.instances.borrow().values() {
         let instantiated_module = instance.instantiated_module;
 
         detect_mem_errors(
@@ -151,7 +151,7 @@ fn detect_combinational_loops<'graph, 'arena>(
     context_arena: &'arena Arena<ModuleContext<'graph, 'arena>>,
     root: &graph::Module<'graph>,
 ) {
-    for instance in m.instances.borrow().iter() {
+    for instance in m.instances.borrow().values() {
         let instantiated_module = instance.instantiated_module;
 
         let context = context.get_child(instance, context_arena);

--- a/kaze/src/verilog.rs
+++ b/kaze/src/verilog.rs
@@ -20,14 +20,14 @@ pub fn generate<'a, W: Write>(m: &'a graph::Module<'a>, w: W) -> Result<()> {
     validate_module_hierarchy(m);
 
     let mut instances = HashMap::new();
-    for instance in m.instances.borrow().iter() {
+    for instance in m.instances.borrow().values() {
         let mut input_names = HashMap::new();
-        for (name, _) in instance.instantiated_module.inputs.borrow().iter() {
+        for name in instance.instantiated_module.inputs.borrow().keys() {
             input_names.insert(name.clone(), format!("__{}_input_{}", instance.name, name));
         }
 
         let mut output_names = HashMap::new();
-        for (name, _) in instance.instantiated_module.outputs.borrow().iter() {
+        for name in instance.instantiated_module.outputs.borrow().keys() {
             output_names.insert(name.clone(), format!("__{}_output_{}", instance.name, name));
         }
 
@@ -41,7 +41,7 @@ pub fn generate<'a, W: Write>(m: &'a graph::Module<'a>, w: W) -> Result<()> {
     }
 
     let mut mems = HashMap::new();
-    for mem in m.mems.borrow().iter() {
+    for mem in m.mems.borrow().values() {
         let mem_name = format!("__mem_{}", mem.name);
         let mut read_signal_names = HashMap::new();
         for (index, (address, enable)) in mem.read_ports.borrow().iter().enumerate() {
@@ -71,7 +71,7 @@ pub fn generate<'a, W: Write>(m: &'a graph::Module<'a>, w: W) -> Result<()> {
     }
 
     let mut regs = HashMap::new();
-    for reg in m.registers.borrow().iter() {
+    for reg in m.registers.borrow().values() {
         match reg.data {
             graph::SignalData::Reg { data } => {
                 let value_name = format!("__reg_{}_{}", data.name, regs.len());


### PR DESCRIPTION
This one is a little more complex than the previous one. The problem is that these values were stored in a vector inside the module,
However, I propose (implementation with this PR) to convert these vectors to maps to make lookup of these names O(1).